### PR TITLE
Remove 1 unnecessary stubbing in ECSCloudTest.removeJunkTemplateProducesNoError

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSCloudTest.java
@@ -114,7 +114,6 @@ public class ECSCloudTest {
     @Test
     public void removeJunkTemplateProducesNoError() throws Exception {
         ECSService ecsService = mock(ECSService.class);
-        when(ecsService.findTaskDefinition(anyString())).thenReturn(null);
         ECSCloud cloud = new ECSCloud("mycloud", "mycluster", ecsService);
         cloud.setRegionName("us-east-1");
         cloud.removeDynamicTemplate(getTaskTemplate(Math.random() + "", "label1, label2, label3"));


### PR DESCRIPTION
In our analysis of the project, we observed that the test `ECSClodTest.removeJunkTemplateProducesNoError` contains an unnecessary stubbing. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.