### PR TITLE
Remove 2 unnecessary stubbings in ECSSlvaeTest.java

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/amazonecs/ECSSlaveTest.java
@@ -77,7 +77,6 @@ public class ECSSlaveTest {
 
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
         TaskListener listener = mock(TaskListener.class);
-        Mockito.when(listener.getLogger()).thenReturn(new PrintStream(bo));
         ECSTaskTemplate template = getTaskTemplate();
 
         ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());
@@ -103,7 +102,6 @@ public class ECSSlaveTest {
 
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
         TaskListener listener = mock(TaskListener.class);
-        Mockito.when(listener.getLogger()).thenReturn(new PrintStream(bo));
         ECSTaskTemplate template = getTaskTemplate();
 
         ECSSlave sut = new ECSSlave(cloud, "myagent", template, new JNLPLauncher());


### PR DESCRIPTION
In our analysis of the project, we observed that the test `ECSSlaveTest.terminate_ThrowsException_ignoreException` and `ECSSlaveTest.terminateRunningTask` contain unnecessary stubbings. Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbings.